### PR TITLE
Don't run main Github workflow on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Drops commit https://github.com/daisy/pipeline-ui/commit/730a25b56275beb46b3dcd37077ab00358f3e8ea which wasn't supposed to be merged. See https://github.com/daisy/pipeline-ui/commit/7e50fd2fbf573fb7670d4adfbd00ffe188b765b1#r95271996.