### PR TITLE
feat(settings): autosave settings

### DIFF
--- a/src/main/data/middlewares/settings.ts
+++ b/src/main/data/middlewares/settings.ts
@@ -4,12 +4,7 @@ import { info, error } from 'electron-log'
 import { existsSync, readFileSync, writeFile } from 'fs'
 import { resolve } from 'path'
 import { ENVIRONMENT } from 'shared/constants'
-import {
-    save,
-    saveTtsConfig,
-    selectTtsConfig,
-    setAutoCheckUpdate,
-} from 'shared/data/slices/settings'
+import { save, setAutoCheckUpdate } from 'shared/data/slices/settings'
 import { checkForUpdate } from 'shared/data/slices/update'
 import { ttsConfigToXml } from 'shared/parser/pipelineXmlConverter/ttsConfigToXml'
 import { ApplicationSettings, TtsVoice } from 'shared/types'
@@ -153,24 +148,6 @@ export function settingsMiddleware({ getState, dispatch }) {
 
         try {
             switch (action.type) {
-                case saveTtsConfig.type:
-                    writeFile(
-                        new URL(settings.ttsConfig.xmlFilepath),
-                        ttsConfigToXml(settings.ttsConfig),
-                        () => {}
-                    )
-                    if (action.payload) {
-                        // re-fetch the /voices endpoint
-                        pipelineAPI
-                            .fetchTtsVoices(selectTtsConfig(getState()))(
-                                selectWebservice(getState())
-                            )
-                            .then((voices: Array<TtsVoice>) => {
-                                console.log('TTS Voices', voices)
-                                dispatch(setTtsVoices(voices))
-                            })
-                    }
-                    break
                 case save.type:
                     // Parse new settings and dispatch updates if needed here
                     nativeTheme.themeSource = settings.colorScheme
@@ -184,15 +161,6 @@ export function settingsMiddleware({ getState, dispatch }) {
                         ttsConfigToXml(settings.ttsConfig),
                         () => {}
                     )
-                    // re-fetch the /voices endpoint
-                    pipelineAPI
-                        .fetchTtsVoices(selectTtsConfig(getState()))(
-                            selectWebservice(getState())
-                        )
-                        .then((voices: Array<TtsVoice>) => {
-                            console.log('TTS Voices', voices)
-                            dispatch(setTtsVoices(voices))
-                        })
                     break
                 case setAutoCheckUpdate.type:
                     if (

--- a/src/renderer/components/TtsEnginesConfig/index.tsx
+++ b/src/renderer/components/TtsEnginesConfig/index.tsx
@@ -1,11 +1,10 @@
 /*
 Select a script and submit a new job
 */
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useWindowStore } from 'renderer/store'
 import { PipelineAPI } from 'shared/data/apis/pipeline'
 import { selectTtsVoices, setTtsVoices } from 'shared/data/slices/pipeline'
-import { saveTtsConfig } from 'shared/data/slices/settings'
 import { TtsVoice } from 'shared/types/ttsConfig'
 
 const enginePropertyKeys = [

--- a/src/shared/data/slices/settings.ts
+++ b/src/shared/data/slices/settings.ts
@@ -99,12 +99,6 @@ export const settings = createSlice({
         ) => {
             state.ttsConfig = action.payload
         },
-        saveTtsConfig: (
-            state: ApplicationSettings,
-            action: PayloadAction<boolean | undefined>
-        ) => {
-            // saveTtsConfig action to trigger middleware save on disk
-        },
     },
 })
 
@@ -118,7 +112,6 @@ export const {
     setClosingMainWindowActionForJobs,
     setTtsConfig,
     setAutoCheckUpdate,
-    saveTtsConfig,
 } = settings.actions
 
 export const selectors = {


### PR DESCRIPTION
Replacing manual settings save by autosaving settings for both settings and tts configurations.

Also:
- unified save action for settings and ttsConfig
- don't reload voices on saving ttsConfig : voices are now only loaded if connection to a new TTS is validated
- deprecation warning removed on select and option element in SettingsView