### PR TITLE
fix(#102): value propagation after synchronized internal state update

### DIFF
--- a/src/renderer/components/Fields/ControlledInput.tsx
+++ b/src/renderer/components/Fields/ControlledInput.tsx
@@ -3,32 +3,9 @@ import { useEffect, useState } from 'react'
 export function ControlledInput(props) {
     const { value, onChange, ...rest } = props
     const [query, setQuery] = useState(props.value)
-    const [propagate, doPropagation] = useState(true)
-
-    useEffect(() => {
-        // Field has changed internally, propagate update
-        if (propagate && onChange) {
-            onChange && onChange(query)
-        } else {
-            // last Update came from parent,
-            // reactivate propagation
-            doPropagation(true)
-        }
-    }, [query])
-
-    // Props update effect
-    useEffect(() => {
-        // Field value has changed from the parent
-        if (query != value) {
-            // Deactivate propagation
-            doPropagation(false)
-            // Update the field
-            setQuery(query)
-        }
-    }, [value])
-
     const handleChange = (e) => {
         setQuery(e.target.value)
+        onChange && onChange(e.target.value)
     }
 
     return <input value={query} onChange={handleChange} {...rest} />

--- a/src/renderer/components/Fields/CustomField.tsx
+++ b/src/renderer/components/Fields/CustomField.tsx
@@ -6,6 +6,7 @@ import { ControlledInput } from './ControlledInput'
 
 export function CustomField({ item, onChange, initialValue, controlId }) {
     const { pipeline } = useWindowStore()
+    const [value, setValue] = useState(initialValue)
     const [userInteracted, setUserInteracted] = useState(false) // false if the user started typing
 
     // find the datatype in the pipeline.datatypes store
@@ -13,6 +14,7 @@ export function CustomField({ item, onChange, initialValue, controlId }) {
 
     let onChangeValue = (newValue) => {
         setUserInteracted(true)
+        setValue(newValue)
         onChange(newValue)
     }
 
@@ -34,7 +36,7 @@ export function CustomField({ item, onChange, initialValue, controlId }) {
                         type="text"
                         required={item.required}
                         // @ts-ignore
-                        value={initialValue ?? ''}
+                        value={value ?? ''}
                         id={controlId}
                         onChange={(e) => onChangeValue(e)}
                         className={userInteracted ? 'interacted' : null}
@@ -55,7 +57,7 @@ export function CustomField({ item, onChange, initialValue, controlId }) {
                     <select
                         id={controlId}
                         onChange={(e) => onChangeValue(e.target.value)}
-                        value={initialValue ?? ''}
+                        value={value ?? ''}
                     >
                         {valueChoices.map((option, idx) => {
                             let displayString =
@@ -88,7 +90,7 @@ export function CustomField({ item, onChange, initialValue, controlId }) {
                 type="text"
                 required={item.required}
                 // @ts-ignore
-                value={initialValue ?? null}
+                value={value ?? null}
                 id={controlId}
                 onChange={(e) => onChangeValue(e)}
                 className={userInteracted ? 'interacted' : null}

--- a/src/renderer/components/Fields/FileOrFolderInput.tsx
+++ b/src/renderer/components/Fields/FileOrFolderInput.tsx
@@ -39,35 +39,11 @@ export function FileOrFolderInput({
     // the value is stored internally as it can be set 2 ways
     // and also broadcast via onChange so that a parent component can subscribe
     const [value, setValue] = useState(initialValue)
-    // Propagation state
-    const [propagate, doPropagation] = useState(true)
     const [userInteracted, setUserInteracted] = useState(false) // false if the user started typing
-
-    // Propagation effect
-    useEffect(() => {
-        // Propagate change
-        if (propagate && onChange) {
-            onChange(value)
-        } else {
-            // change came from props,
-            // reactivate the propagation after updating value
-            doPropagation(true)
-        }
-    }, [value])
-
-    // Props update effect
-    useEffect(() => {
-        // Field value has changed from the parent
-        if (initialValue != value) {
-            // Deactivate propagation
-            doPropagation(false)
-            // Update the field
-            setValue(initialValue)
-        }
-    }, [initialValue])
 
     let updateFilename = (filename) => {
         setValue(filename)
+        onChange && onChange(value)
     }
 
     let onClick = async (e, name) => {
@@ -121,7 +97,12 @@ export function FileOrFolderInput({
                         aria-labelledby={labelledBy ?? ''}
                         disabled={!enabled}
                     ></input>
-                    <button type="button" onClick={(e) => onClick(e, name)} disabled={!enabled} className={enabled ? '' : 'grayedout'}>
+                    <button
+                        type="button"
+                        onClick={(e) => onClick(e, name)}
+                        disabled={!enabled}
+                        className={enabled ? '' : 'grayedout'}
+                    >
                         {buttonLabel}
                     </button>
                 </div>

--- a/src/renderer/components/Fields/FormField.tsx
+++ b/src/renderer/components/Fields/FormField.tsx
@@ -58,7 +58,7 @@ export function FormField({
                         useSystemPath={false}
                         buttonLabel="Browse"
                         required={item.required}
-                        initialValue={initialValue}
+                        initialValue={value}
                         ordered={item.ordered}
                     />
                 )
@@ -83,7 +83,7 @@ export function FormField({
                             useSystemPath={false}
                             buttonLabel="Browse"
                             required={item.required}
-                            initialValue={initialValue}
+                            initialValue={value}
                         />
                     )
                 }
@@ -105,7 +105,7 @@ export function FormField({
                 <CustomField
                     item={item}
                     onChange={(newValue) => onChangeValue(newValue, item)}
-                    initialValue={initialValue ?? ''}
+                    initialValue={value ?? ''}
                     controlId={controlId}
                 />
             )
@@ -116,7 +116,7 @@ export function FormField({
                         type={inputType}
                         required={item.required}
                         // @ts-ignore
-                        value={initialValue ?? ''}
+                        value={value ?? ''}
                         id={controlId}
                         onChange={(e) => onChangeValue(e.target.value, item)}
                     ></input>


### PR DESCRIPTION
Retrying the fix given in https://dev.to/kwirke/solving-caret-jumping-in-react-inputs-36ic with intermediate value storage in state and synchronized state update before propagation.

close #102 