### PR TITLE
Improve configuration for braille-outputting scripts

### DIFF
--- a/src/main/data/middlewares/pipeline.ts
+++ b/src/main/data/middlewares/pipeline.ts
@@ -710,9 +710,32 @@ export function pipelineMiddleware({ getState, dispatch }) {
                         .fetchStylesheetParameters(job)(webservice)
                         .then((parameters) => {
                             console.log('received parameters', parameters)
+                            // update job options with new parameters
+                            const options = [...job.jobRequest.options]
+                            for (let item of parameters) {
+                                const existingOption = options.find(
+                                    (o) => o.name === item.name
+                                )
+                                if (existingOption !== undefined) {
+                                    existingOption.value = item.default
+                                } else {
+                                    // For now, only consider non-uri parameters
+                                    options.push({
+                                        name: item.name,
+                                        value: item.default,
+                                        isFile: false,
+                                    })
+                                }
+                            }
+                            // Also send back the parameters to the UI
+                            // for composition of the script options
                             dispatch(
                                 updateJob({
                                     ...job,
+                                    jobRequest: {
+                                        ...job.jobRequest,
+                                        options: [...options],
+                                    },
                                     stylesheetParameters: parameters,
                                 })
                             )

--- a/src/main/data/middlewares/pipeline.ts
+++ b/src/main/data/middlewares/pipeline.ts
@@ -24,6 +24,7 @@ import {
     setProperties,
     setTtsEngineState,
     setTtsEngineFeatures,
+    requestStylesheetParameters,
 } from 'shared/data/slices/pipeline'
 
 import {
@@ -686,6 +687,19 @@ export function pipelineMiddleware({ getState, dispatch }) {
                             })
                     }
                 }, 1000)
+                break
+            case requestStylesheetParameters.type:
+                const job = action.payload as Job
+                pipelineAPI
+                    .fetchStylesheetParameters(job)(webservice)
+                    .then((parameters) => {
+                        dispatch(
+                            updateJob({
+                                ...job,
+                                stylesheetParameters: parameters,
+                            })
+                        )
+                    })
                 break
             default:
                 if (action.type.startsWith('settings/')) {

--- a/src/renderer/components/Fields/FormField.tsx
+++ b/src/renderer/components/Fields/FormField.tsx
@@ -26,14 +26,9 @@ export function FormField({
     onChange: (value: any, item: ScriptItemBase) => void // function to set the value in a parent-level collection.
     initialValue: any // the initial value for the field
 }) {
-    const [value, setValue] = useState(initialValue)
     const [checked, setChecked] = useState(true)
     let controlId = `${idprefix}-${item.name}`
 
-    let onChangeValue = (newValue: any, scriptItem: ScriptItemBase) => {
-        setValue(newValue)
-        onChange(newValue, scriptItem)
-    }
     let dialogOpts = ['anyFileURI', 'anyURI'].includes(item.type)
         ? ['openFile']
         : item.type == 'anyDirURI'
@@ -41,7 +36,6 @@ export function FormField({
         : ['openFile', 'openDirectory']
 
     const { settings } = useWindowStore()
-
     let matchType = (item) => {
         let inputType = findInputType(item.type)
         if (inputType == 'file') {
@@ -53,11 +47,11 @@ export function FormField({
                         elemId={controlId}
                         mediaType={item.mediaType}
                         name={item.name}
-                        onChange={(filenames) => onChangeValue(filenames, item)}
+                        onChange={(filenames) => onChange(filenames, item)}
                         useSystemPath={false}
                         buttonLabel="Browse"
                         required={item.required}
-                        initialValue={value}
+                        initialValue={initialValue}
                         ordered={item.ordered}
                     />
                 )
@@ -76,13 +70,11 @@ export function FormField({
                             elemId={controlId}
                             mediaType={item.mediaType}
                             name={item.name}
-                            onChange={(filename) =>
-                                onChangeValue(filename, item)
-                            }
+                            onChange={(filename) => onChange(filename, item)}
                             useSystemPath={false}
                             buttonLabel="Browse"
                             required={item.required}
-                            initialValue={value}
+                            initialValue={initialValue}
                         />
                     )
                 }
@@ -93,9 +85,11 @@ export function FormField({
                     <input
                         type={inputType}
                         required={item.required}
-                        onChange={(e) => onChangeValue(e.target.checked, item)}
+                        onChange={(e) => onChange(e.target.checked, item)}
                         id={controlId}
-                        checked={value === 'true' || value === true}
+                        checked={
+                            initialValue === 'true' || initialValue === true
+                        }
                     ></input>
                 </>
             )
@@ -103,8 +97,8 @@ export function FormField({
             return (
                 <CustomField
                     item={item}
-                    onChange={(newValue) => onChangeValue(newValue, item)}
-                    initialValue={value ?? ''}
+                    onChange={(newValue) => onChange(newValue, item)}
+                    initialValue={initialValue ?? ''}
                     controlId={controlId}
                 />
             )
@@ -114,10 +108,9 @@ export function FormField({
                     <input
                         type={inputType}
                         required={item.required}
-                        // @ts-ignore
-                        value={value ?? ''}
+                        value={initialValue ?? ''}
                         id={controlId}
-                        onChange={(e) => onChangeValue(e.target.value, item)}
+                        onChange={(e) => onChange(e.target.value, item)}
                     ></input>
                 </>
             )

--- a/src/renderer/components/Fields/FormField.tsx
+++ b/src/renderer/components/Fields/FormField.tsx
@@ -23,23 +23,22 @@ export function FormField({
 }: {
     item: ScriptItemBase
     idprefix: string
-    onChange: (string, ScriptItemBase) => void // function to set the value in a parent-level collection.
+    onChange: (value: any, item: ScriptItemBase) => void // function to set the value in a parent-level collection.
     initialValue: any // the initial value for the field
 }) {
     const [value, setValue] = useState(initialValue)
     const [checked, setChecked] = useState(true)
     let controlId = `${idprefix}-${item.name}`
 
-    let onChangeValue = (newValue, scriptItem) => {
+    let onChangeValue = (newValue: any, scriptItem: ScriptItemBase) => {
         setValue(newValue)
         onChange(newValue, scriptItem)
     }
-    let dialogOpts =
-        item.type == 'anyFileURI'
-            ? ['openFile']
-            : item.type == 'anyDirURI'
-            ? ['openDirectory']
-            : ['openFile', 'openDirectory']
+    let dialogOpts = ['anyFileURI', 'anyURI'].includes(item.type)
+        ? ['openFile']
+        : item.type == 'anyDirURI'
+        ? ['openDirectory']
+        : ['openFile', 'openDirectory']
 
     const { settings } = useWindowStore()
 

--- a/src/renderer/components/ScriptForm/index.tsx
+++ b/src/renderer/components/ScriptForm/index.tsx
@@ -1,7 +1,13 @@
 /*
 Fill out fields for a new job and submit it
 */
-import { Job, NameValue, Script, ScriptItemBase } from 'shared/types'
+import {
+    Job,
+    NameValue,
+    Script,
+    ScriptItemBase,
+    ScriptOption,
+} from 'shared/types'
 import { useState } from 'react'
 import { useWindowStore } from 'renderer/store'
 import {
@@ -41,6 +47,8 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
     let optional = getAllOptional(script)
     const { settings } = useWindowStore()
 
+    const filteredOptions = ['stylesheet', 'page-width', 'page-height']
+    const hiddenOptions = ['transform', 'stylesheet-parameters']
     // for script that have stylesheet parameter available
     // the job request must be splitted in two step
     // First only display the following parameters
@@ -51,7 +59,7 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
     const isMultistep = optional.findIndex((item) => item.name === 'stylesheet')
     if (isMultistep > -1) {
         optional = optional.filter((item) =>
-            ['stylesheet', 'page-width', 'page-height'].includes(item.name)
+            filteredOptions.includes(item.name)
         )
     }
     // next will send back the partial jobRequest to the backend
@@ -66,7 +74,21 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
     // When this property is set
     if (job.stylesheetParameters != null) {
         required = []
-        optional = [/*...optional,*/ ...job.stylesheetParameters]
+        optional = [
+            ...getAllOptional(script)
+                .filter((item) => !filteredOptions.includes(item.name))
+                .filter((item) => !hiddenOptions.includes(item.name)),
+        ]
+        for (let item of job.stylesheetParameters) {
+            const existingOption = optional.find(
+                (o) => o.name === item.name
+            ) as ScriptOption
+            if (existingOption.name === item.name) {
+                existingOption.default = item.default
+            } else {
+                optional.push(item)
+            }
+        }
     }
 
     // Allow the user to go back to first inputs and options set

--- a/src/renderer/components/ScriptForm/index.tsx
+++ b/src/renderer/components/ScriptForm/index.tsx
@@ -81,8 +81,8 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
         for (let item of job.stylesheetParameters) {
             const existingOption = optional.find(
                 (o) => o.name === item.name
-            ) as ScriptOption
-            if (existingOption.name === item.name) {
+            ) as ScriptOption | undefined
+            if (existingOption !== undefined) {
                 existingOption.default = item.default
             } else {
                 optional.push(item)

--- a/src/renderer/components/ScriptForm/index.tsx
+++ b/src/renderer/components/ScriptForm/index.tsx
@@ -223,45 +223,28 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
                                         ) ? (
                                             '' // skip it, we don't need to provide a visual field for this option, it's set globally
                                         ) : (
-                                            <li key={idx}>
-                                                {item.mediaType?.includes(
-                                                    'text/css'
-                                                ) ? (
-                                                    <FormField
-                                                        item={{
-                                                            ...item,
-                                                            kind: 'anyFile',
-                                                        }}
-                                                        key={idx}
-                                                        idprefix={`${ID(
-                                                            job.internalId
-                                                        )}-optional`}
-                                                        onChange={
-                                                            saveValueInJobRequest
-                                                        }
-                                                        initialValue={findValue(
-                                                            item.name,
-                                                            'anyFile',
-                                                            job.jobRequest
-                                                        )}
-                                                    />
-                                                ) : (
-                                                    <FormField
-                                                        item={item}
-                                                        key={idx}
-                                                        idprefix={`${ID(
-                                                            job.internalId
-                                                        )}-optional`}
-                                                        onChange={
-                                                            saveValueInJobRequest
-                                                        }
-                                                        initialValue={findValue(
-                                                            item.name,
-                                                            item.kind,
-                                                            job.jobRequest
-                                                        )}
-                                                    />
-                                                )}
+                                            <li
+                                                key={`${ID(job.internalId)}-${
+                                                    item.name
+                                                }-li`}
+                                            >
+                                                <FormField
+                                                    item={item}
+                                                    key={`${ID(
+                                                        job.internalId
+                                                    )}-${item.name}-FormField`}
+                                                    idprefix={`${ID(
+                                                        job.internalId
+                                                    )}-${item.name}-optional`}
+                                                    onChange={
+                                                        saveValueInJobRequest
+                                                    }
+                                                    initialValue={findValue(
+                                                        item.name,
+                                                        item.kind,
+                                                        job.jobRequest
+                                                    )}
+                                                />
                                             </li>
                                         )
                                     )}

--- a/src/renderer/components/ScriptForm/index.tsx
+++ b/src/renderer/components/ScriptForm/index.tsx
@@ -179,33 +179,37 @@ export function ScriptForm({ job, script }: { job: Job; script: Script }) {
             {!submitInProgress ? (
                 <form onSubmit={onSubmit} id={`${ID(job.internalId)}-form`}>
                     <div className="form-sections">
-                        <section
-                            className="required-fields"
-                            aria-labelledby={`${ID(job.internalId)}-required`}
-                        >
-                            <h2 id={`${ID(job.internalId)}-required`}>
-                                Required information
-                            </h2>
-                            <ul className="fields">
-                                {required.map((item, idx) => (
-                                    <li key={idx}>
-                                        <FormField
-                                            item={item}
-                                            key={idx}
-                                            idprefix={`${ID(
-                                                job.internalId
-                                            )}-required`}
-                                            onChange={saveValueInJobRequest}
-                                            initialValue={findValue(
-                                                item.name,
-                                                item.kind,
-                                                job.jobRequest
-                                            )}
-                                        />
-                                    </li>
-                                ))}
-                            </ul>
-                        </section>
+                        {required.length > 0 && (
+                            <section
+                                className="required-fields"
+                                aria-labelledby={`${ID(
+                                    job.internalId
+                                )}-required`}
+                            >
+                                <h2 id={`${ID(job.internalId)}-required`}>
+                                    Required information
+                                </h2>
+                                <ul className="fields">
+                                    {required.map((item, idx) => (
+                                        <li key={idx}>
+                                            <FormField
+                                                item={item}
+                                                key={idx}
+                                                idprefix={`${ID(
+                                                    job.internalId
+                                                )}-required`}
+                                                onChange={saveValueInJobRequest}
+                                                initialValue={findValue(
+                                                    item.name,
+                                                    item.kind,
+                                                    job.jobRequest
+                                                )}
+                                            />
+                                        </li>
+                                    ))}
+                                </ul>
+                            </section>
+                        )}
                         {optional.length > 0 ? (
                             <section
                                 className="optional-fields"

--- a/src/renderer/store/index.tsx
+++ b/src/renderer/store/index.tsx
@@ -1,53 +1,16 @@
 import { useContext, createContext, useState, useEffect } from 'react'
-import {
-    PipelineState,
-    PipelineStatus,
-    Webservice,
-    baseurl,
-    Script,
-    ApplicationSettings,
-} from 'shared/types'
-import {
-    scriptsXmlToJson,
-    scriptXmlToJson,
-} from 'shared/parser/pipelineXmlConverter'
 import { RootState } from 'shared/types/store'
 import { getInitialState } from 'shared/data/store'
 import { slices } from 'shared/data/slices'
 
 export interface WindowStore {
     reduxStore: RootState
-    // about: {
-    //     isOpen: boolean
-    // }
-    // pipeline: PipelineState
-    // messages: Array<string>
-    // errors: Array<string>
-    // scripts: Array<Script>
-    // settings: ApplicationSettings
-    // // react dispatcher
-    // setPipelineState?: React.Dispatch<React.SetStateAction<PipelineState>>
-    // setAboutWindowState?: React.Dispatch<
-    //     React.SetStateAction<{ isOpen: boolean }>
-    // >
-    // setPipelineErrors?: React.Dispatch<React.SetStateAction<string[]>>
-    // setPipelineMessages?: React.Dispatch<React.SetStateAction<string[]>>
-    // setSettings?: React.Dispatch<React.SetStateAction<ApplicationSettings>>
 }
 
 const { App } = window
 
 const WindowStoreContext = createContext({
     reduxStore: getInitialState(),
-    // about: {
-    //     isOpen: false,
-    // },
-    // pipeline: {
-    //     status: PipelineStatus.UNKNOWN,
-    // },
-    // messages: [],
-    // errors: [],
-    // scripts: [],
 } as WindowStore)
 
 export function useWindowStore() {
@@ -72,22 +35,8 @@ export function WindowStoreProvider({ children }) {
         }
     )
 
-    // const [about, setAboutWindowState] = useState({
-    //     isOpen: false,
-    // })
-    // const [pipeline, setPipelineState] = useState<PipelineState>({
-    //     status: PipelineStatus.UNKNOWN,
-    // })
-    // const [messages, setPipelineMessages] = useState<Array<string>>([])
-    // const [errors, setPipelineErrors] = useState<Array<string>>([])
-    // const [scripts, setScripts] = useState<Array<Script>>([])
-    // const [settings, setSettings] = useState<ApplicationSettings>({
-    //     downloadFolder: '',
-    // })
-
     useEffect(() => {
         slices.forEach((slice) => {
-            //console.log('useEffect', slice)
             Object.entries(slice.actions).forEach(([name, { type }]) => {
                 console.log('create listeners on ', type)
                 App.store.onSliceUpdate(type, (newSliceState) => {
@@ -101,17 +50,6 @@ export function WindowStoreProvider({ children }) {
 
     const sharedStore = {
         reduxStore: reduxStore,
-        // about: about,
-        // pipeline: pipeline,
-        // messages: messages,
-        // errors: errors,
-        // scripts: scripts,
-        // settings: settings,
-        // setAboutWindowState,
-        // setPipelineState,
-        // setPipelineMessages,
-        // setPipelineErrors,
-        // setSettings,
     }
 
     return (

--- a/src/renderer/utils/utils.ts
+++ b/src/renderer/utils/utils.ts
@@ -39,9 +39,7 @@ export function findValue(name: string, kind: string, jobRequest: JobRequest) {
 
 export function findInputType(type) {
     let inputType = ''
-    if (type == 'anyFileURI') {
-        inputType = 'file'
-    } else if (type == 'anyDirURI') {
+    if (['anyFileURI', 'anyDirURI', 'anyURI'].includes(type)) {
         inputType = 'file'
     } else if (['xsd:dateTime', 'xs:dateTime', 'datetime'].includes(type)) {
         inputType = 'datetime-local'

--- a/src/shared/constants/filetypes.ts
+++ b/src/shared/constants/filetypes.ts
@@ -32,12 +32,16 @@ const mediaTypesFileFilters = {
         extensions: ['xml'],
     },
     'text/html': {
-        name: '',
-        extensions: [''],
-    },
-    'text/css': {
         name: 'HTML Document',
         extensions: ['html'],
+    },
+    'text/css': {
+        name: 'CSS Document',
+        extensions: ['css'],
+    },
+    'text/x-scss': {
+        name: 'SCSS Document',
+        extensions: ['scss'],
     },
     'application/xslt+xml': {
         name: 'XSLT Document',

--- a/src/shared/data/apis/pipeline.ts
+++ b/src/shared/data/apis/pipeline.ts
@@ -26,6 +26,8 @@ import { jobResponseXmlToJson } from 'shared/parser/pipelineXmlConverter/jobResp
 import { propertiesXmlToJson } from 'shared/parser/pipelineXmlConverter/propertiesXmlToJson'
 import { propertyToXml } from 'shared/parser/pipelineXmlConverter/propertyToXml'
 import { ttsEnginesToJson } from 'shared/parser/pipelineXmlConverter/ttsEnginesToJson'
+import { parametersXmlToJson } from 'shared/parser/pipelineXmlConverter/parametersXmlToJson'
+import { jobToStylesheetParametersXml } from 'shared/parser/pipelineXmlConverter/jobToStylesheetParametersXml'
 
 //import fetch, { Response, RequestInit } from 'node-fetch'
 //import { info, error } from 'electron-log'
@@ -202,6 +204,24 @@ export class PipelineAPI {
         return this.createPipelineFetchFunction(
             (ws) => `${baseurl(ws)}/tts-engines`,
             (text) => ttsEnginesToJson(text)
+        )
+    }
+    // New /stylesheet-parameters endpoint : https://github.com/daisy/pipeline-ui/issues/198
+    // and https://github.com/daisy/pipeline/issues/750
+    /**
+     * Fetch new script options from a braille targeted job with
+     * inputs, stylesheet, page-width and page-height parameters set
+     * @param j the braille job
+     * @returns the script options to use for the job
+     */
+    fetchStylesheetParameters(j: Job) {
+        return this.createPipelineFetchFunction(
+            (ws) => `${baseurl(ws)}/stylesheet-parameters`,
+            (text) => parametersXmlToJson(text),
+            {
+                method: 'POST',
+                body: jobToStylesheetParametersXml(j),
+            }
         )
     }
 }

--- a/src/shared/data/slices/pipeline.ts
+++ b/src/shared/data/slices/pipeline.ts
@@ -74,7 +74,7 @@ export const pipeline = createSlice({
         /**
          * Stop the pipeline instance
          *
-         * (Middleware handled action )
+         * (Middleware handled action)
          * @param state current pipeline state
          * @param action payload with a boolean : if true, then app is closing
          */
@@ -239,6 +239,19 @@ export const pipeline = createSlice({
                 state.selectedJobId = state.jobs[0].internalId
             }
         },
+        /**
+         * Request script options from stylesheet parameters endpoint
+         *
+         * (Middleware handled action )
+         * @param state current pipeline state
+         * @param action payload with a boolean : if true, then app is closing
+         */
+        requestStylesheetParameters: (
+            state: PipelineState,
+            param: PayloadAction<Job>
+        ) => {
+            // Handled by the middleware
+        },
         runJob: (state: PipelineState, param: PayloadAction<Job>) => {
             if (param.payload.jobRequest) {
                 // Retrieve latest JobRequest payload
@@ -349,6 +362,7 @@ export const {
     setProperties,
     setTtsEngineState,
     setTtsEngineFeatures,
+    requestStylesheetParameters,
 } = pipeline.actions
 
 export const selectors = {

--- a/src/shared/parser/pipelineXmlConverter/jobToStylesheetParametersXml.ts
+++ b/src/shared/parser/pipelineXmlConverter/jobToStylesheetParametersXml.ts
@@ -21,12 +21,13 @@ function jobToStylesheetParametersXml(j: Job): string {
     const height = j.jobRequest.options.filter(
         (option) => option.name === 'page-height'
     )[0]
-    return `<parameters xmlns="http://www.daisy.org/ns/pipeline/data">
+    return `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<parameters xmlns="http://www.daisy.org/ns/pipeline/data">
     <media value="embossed AND (width:${width.value}) AND (height:${
         height.value
     })"/>
     <userStylesheets>${
-        stylesheet !== undefined && `<file href="${stylesheet.value}"/>`
+        stylesheet && stylesheet.value && `<file href="${stylesheet.value}"/>`
     }</userStylesheets>
     <sourceDocument>${j.jobRequest.inputs
         .filter((input) => input.isFile && !input.name.endsWith('.scss'))

--- a/src/shared/parser/pipelineXmlConverter/jobToStylesheetParametersXml.ts
+++ b/src/shared/parser/pipelineXmlConverter/jobToStylesheetParametersXml.ts
@@ -1,0 +1,38 @@
+import { Job } from 'shared/types'
+
+/**
+ * Build a request xml string that can be sent to pipeline on the
+ * "stylesheet-parameters" using the job inputs and the following
+ * identified options :
+ * - stylesheet
+ * - page-width
+ * - page-height
+ * @param {Job} j the job to be used for building the xml
+ * @returns {string} an xml string that can be sent to a DP2 engine to get
+ * new script parameters
+ */
+function jobToStylesheetParametersXml(j: Job): string {
+    const stylesheet = j.jobRequest.options.filter(
+        (option) => option.name === 'stylesheet'
+    )[0]
+    const width = j.jobRequest.options.filter(
+        (option) => option.name === 'page-width'
+    )[0]
+    const height = j.jobRequest.options.filter(
+        (option) => option.name === 'page-height'
+    )[0]
+    return `<parameters xmlns="http://www.daisy.org/ns/pipeline/data">
+    <media value="embossed AND (width:${width.value}) AND (height:${
+        height.value
+    })"/>
+    <userStylesheets>${
+        stylesheet !== undefined && `<file href="${stylesheet.value}"/>`
+    }</userStylesheets>
+    <sourceDocument>${j.jobRequest.inputs
+        .filter((input) => input.isFile && !input.name.endsWith('.scss'))
+        .map((input) => `<file href="${input.value}"/>`)
+        .join('')}</sourceDocument>
+</parameters>`
+}
+
+export { jobToStylesheetParametersXml }

--- a/src/shared/parser/pipelineXmlConverter/parametersXmlToJson.ts
+++ b/src/shared/parser/pipelineXmlConverter/parametersXmlToJson.ts
@@ -1,0 +1,29 @@
+import { Job, ScriptOption } from 'shared/types'
+import { parseXml } from './parser'
+
+// Get new script options from a stylesheet parameters options
+function parametersXmlToJson(xmlString: string): ScriptOption[] {
+    let parametersElm = parseXml(xmlString, 'parameters')
+    const result: ScriptOption[] = []
+    for (const propElem of parametersElm.getElementsByTagName('parameter')) {
+        const name = propElem.getAttribute('name')
+        const value = propElem.getAttribute('default')
+        const kind = propElem.getAttribute('type')
+        const nicename = propElem.getAttribute('nicename')
+        const description = propElem.getAttribute('description')
+        result.push({
+            desc: propElem.getAttribute('description'),
+            name: propElem.getAttribute('name'),
+            sequence: propElem.getAttribute('sequence') == 'true', // should always be false
+            required: propElem.getAttribute('required') == 'true', // should always be false
+            nicename: propElem.getAttribute('nicename'),
+            ordered: propElem.getAttribute('ordered') == 'true', // should always be false
+            type: propElem.getAttribute('type'),
+            default: propElem.getAttribute('default'),
+            kind: 'option',
+        } as ScriptOption)
+    }
+    return result
+}
+
+export { parametersXmlToJson }

--- a/src/shared/parser/pipelineXmlConverter/parametersXmlToJson.ts
+++ b/src/shared/parser/pipelineXmlConverter/parametersXmlToJson.ts
@@ -5,25 +5,20 @@ import { parseXml } from './parser'
 function parametersXmlToJson(xmlString: string): ScriptOption[] {
     let parametersElm = parseXml(xmlString, 'parameters')
     const result: ScriptOption[] = []
-    for (const propElem of parametersElm.getElementsByTagName('parameter')) {
-        const name = propElem.getAttribute('name')
-        const value = propElem.getAttribute('default')
-        const kind = propElem.getAttribute('type')
-        const nicename = propElem.getAttribute('nicename')
-        const description = propElem.getAttribute('description')
-        result.push({
-            desc: propElem.getAttribute('description'),
-            name: propElem.getAttribute('name'),
-            sequence: propElem.getAttribute('sequence') == 'true', // should always be false
-            required: propElem.getAttribute('required') == 'true', // should always be false
-            nicename: propElem.getAttribute('nicename'),
-            ordered: propElem.getAttribute('ordered') == 'true', // should always be false
-            type: propElem.getAttribute('type'),
-            default: propElem.getAttribute('default'),
-            kind: 'option',
-        } as ScriptOption)
-    }
-    return result
+    return Array.from(parametersElm.getElementsByTagName('parameter')).map(
+        (propElem: any) =>
+            ({
+                desc: propElem.getAttribute('description'),
+                name: propElem.getAttribute('name'),
+                sequence: propElem.getAttribute('sequence') == 'true', // should always be false
+                required: propElem.getAttribute('required') == 'true', // should always be false
+                nicename: propElem.getAttribute('nicename'),
+                ordered: propElem.getAttribute('ordered') == 'true', // should always be false
+                type: propElem.getAttribute('type'),
+                default: propElem.getAttribute('default'),
+                kind: 'option',
+            } as ScriptOption)
+    )
 }
 
 export { parametersXmlToJson }

--- a/src/shared/types/pipeline.ts
+++ b/src/shared/types/pipeline.ts
@@ -199,6 +199,11 @@ export type Job = {
     invisible?: boolean
     // jobRequest.script also has script info (returned from ws);
     // however, storing it separately gives us access to more details
+    /**
+     * For job with a stylesheet parameter, supplementary options are retrieved
+     * from the pipeline stylesheet-parameters end point and stored here.
+     */
+    stylesheetParameters?: ScriptOption[]
 }
 // JobData is the JSON representation of Pipeline WS data for a single job
 export type JobData = {


### PR DESCRIPTION
This pull request modify braille outputting scripts (ending in `to-pef`)  to use the new `stylesheet-parameters` endpoint as to complete and/or simplify the scripts settings by relying on user stylesheets.

Closes #198 
Closes #207 

