### PR TITLE
feat(settings): new settings migration utility for evolutions

### DIFF
--- a/src/main/factories/windows/create.ts
+++ b/src/main/factories/windows/create.ts
@@ -6,6 +6,7 @@ import { selectPipeline } from 'shared/data/slices/pipeline'
 import { selectSettings } from 'shared/data/slices/settings'
 import { WindowProps } from 'shared/types'
 import { APP_CONFIG } from '~/app.config'
+
 import { PipelineInstance } from '../ipcs/pipeline'
 
 /**

--- a/src/renderer/components/SettingsView/index.tsx
+++ b/src/renderer/components/SettingsView/index.tsx
@@ -2,19 +2,18 @@ import { useEffect, useState } from 'react'
 import { useWindowStore } from 'renderer/store'
 import {
     ApplicationSettings,
-    ClosingMainWindowActionForApp,
-    ClosingMainWindowActionForJobs,
+    ClosingMainWindowAction,
     ColorScheme,
 } from 'shared/types'
 import { FileOrFolderInput } from '../Fields/FileOrFolderInput'
 import {
     save,
     setTtsConfig,
-    setClosingMainWindowActionForApp,
     setDownloadPath,
     setColorScheme,
     setAutoCheckUpdate,
-    setClosingMainWindowActionForJobs,
+    setClosingMainWindowAction,
+    setEditJobOnNewTab,
 } from 'shared/data/slices/settings'
 import { TtsVoicesConfigPane } from '../TtsVoicesConfig'
 import { TtsEnginesConfigPane } from '../TtsEnginesConfig'
@@ -39,10 +38,7 @@ export function SettingsView() {
     // (without affecting the rest of the app)
     const [newSettings, setNewSettings] = useState<ApplicationSettings>({
         ...settings,
-        appStateOnClosingMainWindow:
-            settings.appStateOnClosingMainWindow ?? 'ask', // defaults to ask in form
-        jobsStateOnClosingMainWindow:
-            settings.jobsStateOnClosingMainWindow ?? 'close', // defaults to ask in form
+        onClosingMainWindow: settings.onClosingMainWindow ?? 'ask', // defaults to ask in form
         ttsConfig: {
             ...settings.ttsConfig,
         },
@@ -52,10 +48,7 @@ export function SettingsView() {
         // Reload settings from store if it has changed
         setNewSettings({
             ...settings,
-            appStateOnClosingMainWindow:
-                settings.appStateOnClosingMainWindow ?? 'ask', // defaults to ask in form
-            jobsStateOnClosingMainWindow:
-                settings.jobsStateOnClosingMainWindow ?? 'close', // defaults to ask in form
+            onClosingMainWindow: settings.onClosingMainWindow ?? 'ask', // defaults to ask in form
             ttsConfig: {
                 ...settings.ttsConfig,
             },
@@ -82,34 +75,24 @@ export function SettingsView() {
         App.store.dispatch(save())
         //setSaved(true)
     }
-    const AppClosingActionChanged = (e) => {
+    const ClosingActionChanged = (e) => {
         App.store.dispatch(
-            setClosingMainWindowActionForApp(
-                Object.keys(ClosingMainWindowActionForApp)[
+            setClosingMainWindowAction(
+                Object.keys(ClosingMainWindowAction)[
                     e.target.selectedIndex
-                ] as keyof typeof ClosingMainWindowActionForApp
+                ] as keyof typeof ClosingMainWindowAction
             )
         )
         App.store.dispatch(save())
-        //setSaved(true)
     }
-
     const autoCheckUpdateChanged = (e) => {
         App.store.dispatch(setAutoCheckUpdate(e.target.checked))
         App.store.dispatch(save())
-        //setSaved(true)
     }
 
-    const JobsClosingActionChanged = (e) => {
-        App.store.dispatch(
-            setClosingMainWindowActionForJobs(
-                Object.keys(ClosingMainWindowActionForJobs)[
-                    e.target.selectedIndex
-                ] as keyof typeof ClosingMainWindowActionForJobs
-            )
-        )
+    const editJobOnNewTabChanged = (e) => {
+        App.store.dispatch(setEditJobOnNewTab(e.target.checked))
         App.store.dispatch(save())
-        //setSaved(true)
     }
 
     const onTtsVoicesPreferenceChange = (voices) => {
@@ -133,7 +116,7 @@ export function SettingsView() {
         App.store.dispatch(save())
         //setSaved(true)
     }
-    
+
     return (
         <div className="settings">
             <nav className="settings-menu">
@@ -311,55 +294,42 @@ export function SettingsView() {
                     ) : selectedSection == SelectedMenuItem.Behavior ? (
                         <>
                             <div className="form-field">
-                                <label htmlFor="appStateOnMainWindowClosing">
+                                <label htmlFor="editJobOnNewTab">
+                                    Editing jobs in new tabs
+                                </label>
+                                <span className="description">
+                                    If checked, editing a job will open a
+                                    pre-filled new job instead of reuse the
+                                    existing job.
+                                </span>
+                                <input
+                                    type="checkbox"
+                                    id="editJobOnNewTab"
+                                    checked={newSettings.editJobOnNewTab}
+                                    onChange={editJobOnNewTabChanged}
+                                />
+                            </div>
+                            <div className="form-field">
+                                <label htmlFor="OnMainWindowClosing">
                                     Action on closing the app window
                                 </label>
                                 <span className="description">
                                     Choose here if you want to keep the
-                                    application running in the tray or close it
-                                    when closing the app window.
-                                </span>
-                                <select
-                                    id="appStateOnMainWindowClosing"
-                                    onChange={(e) => AppClosingActionChanged(e)}
-                                    value={
-                                        newSettings.appStateOnClosingMainWindow
-                                    }
-                                >
-                                    {Object.entries(
-                                        ClosingMainWindowActionForApp
-                                    ).map(([k, v]: [string, string]) => {
-                                        return (
-                                            <option key={k} value={k}>
-                                                {v}
-                                            </option>
-                                        )
-                                    })}
-                                </select>
-                            </div>
-                            <div className="form-field">
-                                <label htmlFor="jobsStateOnMainWindowClosing">
-                                    Keep jobs open when closing the app window
-                                </label>
-                                <span className="description">
-                                    By default, when closing the app window, all
-                                    non-running jobs are closed.
+                                    application running in the tray or quit the
+                                    application when closing the jobs window.
                                     <br />
-                                    Here you can choose to keep the jobs in
-                                    memory when closing the window so that they
-                                    reload on reopening the app window.
+                                    If the application should stay in the tray,
+                                    you can choose if you want to keep jobs
+                                    opened or if they should be closed when the
+                                    window is closed.
                                 </span>
                                 <select
-                                    id="jobsStateOnMainWindowClosing"
-                                    onChange={(e) =>
-                                        JobsClosingActionChanged(e)
-                                    }
-                                    value={
-                                        newSettings.jobsStateOnClosingMainWindow
-                                    }
+                                    id="OnMainWindowClosing"
+                                    onChange={(e) => ClosingActionChanged(e)}
+                                    value={newSettings.onClosingMainWindow}
                                 >
                                     {Object.entries(
-                                        ClosingMainWindowActionForJobs
+                                        ClosingMainWindowAction
                                     ).map(([k, v]: [string, string]) => {
                                         return (
                                             <option key={k} value={k}>

--- a/src/shared/types/pipeline.ts
+++ b/src/shared/types/pipeline.ts
@@ -57,18 +57,26 @@ export type PipelineState = {
     // errors: Array<string>
 }
 
+export enum PipelineType {
+    embedded = 'Use embedded DAISY Pipeline 2',
+    // For later use : system wide already installed pipeline 2, and remotely installed pipeline
+    // system = 'Use and manage an other installed DAISY Pipeline 2 (with webservice module)',
+    // remote = 'Use a remote DAISY Pipeline 2',
+}
+
 /**
  * Properties for initializing ipc with the daisy pipeline 2
- * TODO: rename this to explicit it is properties use on the pipeline js runner
- * side (Note the pipeline engine itself)
+ * - also include the type of instance managed by IPC (embedded, system, or remote)
+ *
  */
 export type PipelineInstanceProperties = {
+    pipelineType?: keyof typeof PipelineType
     /**
      * optional path of the local installation of the pipeline,
      *
      * defaults to the application resources/daisy-pipeline
      */
-    localPipelineHome?: string
+    pipelineHome?: string
 
     appDataFolder?: string
 

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -6,26 +6,166 @@ export enum ColorScheme {
     light = 'Light mode',
     dark = 'Dark mode',
 }
-
-export enum ClosingMainWindowActionForApp {
-    keep = 'Keep running in the tray',
-    close = 'Close the application',
-    ask = 'Ask when closing window',
+export enum ClosingMainWindowAction {
+    keepall = 'Keep all jobs opened with the application running in tray',
+    keepengine = 'Close all jobs but keep the application running in tray',
+    close = 'Quit the application',
+    ask = 'Ask the preferred action on closing the window',
 }
 
-export enum ClosingMainWindowActionForJobs {
-    keep = 'Keep all jobs opened',
-    close = 'Close all non-running jobs',
-}
+// Idea of evolutions :
+// allow connection to multiple pipelines at the same time with an array of pipeline properties
+// This could allow the calling of scripts from pipeline with different features enabled, like specific TTS systems (acapela or SAPI)
 
+/**
+ * 1.0.0
+ * - Adding settingsVersion for upgrading
+ * - Updated the pipeline instance properties
+ * - Merged app and job actions on closing main window
+ */
 export type ApplicationSettings = {
+    settingsVersion: '1.3.0'
+    // Default folder to download the results on the user disk
+    downloadFolder?: string
+    // Pipeline instance properties for IPCs
+    pipelineInstanceProps?: PipelineInstanceProperties
+    // Dark mode selector
+    colorScheme: keyof typeof ColorScheme
+    // Actions to perform when closing the main window
+    onClosingMainWindow?: keyof typeof ClosingMainWindowAction
+    editJobOnNewTab?: boolean
+    // tts preferred voices
+    ttsConfig?: TtsConfig
+    autoCheckUpdate?: boolean
+}
+
+export function migrateSettings(
+    settings: ApplicationSettings | _ApplicationSettings_v0
+): ApplicationSettings {
+    // Take the content of the settings file
+    // And apply migration process in order based on current settings version
+    const migratorsKeys = Array.from(migrators.keys()).reverse()
+    const lastMigrator = migratorsKeys.indexOf(settings['settingsVersion'])
+    let newSettings = Object.assign({}, settings)
+    for (const migratorVersionToApply of migratorsKeys.filter(
+        (m, i) => i > lastMigrator
+    )) {
+        console.log('Migrating settings to version', migratorVersionToApply)
+        newSettings = migrators.get(migratorVersionToApply)(newSettings)
+    }
+    return newSettings as ApplicationSettings
+}
+
+/**
+ * Settings incremental migrators :
+ * A migrator take the last-release setting type and update it to the newest
+ * The migrator key should be the version targeted by the change
+ * (For example, if we are updating settings for app version 1.0.0,
+ * we should add a migrator with key '1.0.0' at the begining of the map)
+ *
+ * Always add the latest migrator at the begining of the map
+ * (migrate use the first key as last iterator to apply )
+ */
+const migrators: Map<string, (prev: any) => any> = new Map<
+    string,
+    (prev: any) => any
+>([
+    // Insert new migrators here as [ 'version', (prev) => ApplicationSettings ]
+    // Don't forget to update the settings class of previous migrators
+    [
+        '1.3.0',
+        (prev: _ApplicationSettings_v0): ApplicationSettings => {
+            const {
+                // Removed, changed or renamed :
+                runLocalPipeline,
+                localPipelineProps,
+                useRemotePipeline,
+                remotePipelineWebservice,
+                appStateOnClosingMainWindow,
+                jobsStateOnClosingMainWindow,
+                // remaining unchanged settings
+                ...toKeep
+            } = prev
+            // changes in pipeline properties
+
+            let localPipelineHome = undefined
+            let prevPipelinePros = {}
+            if (localPipelineProps) {
+                let { localPipelineHome: temp, ..._prev } = localPipelineProps
+                localPipelineHome = temp
+                prevPipelinePros = _prev
+            }
+
+            return {
+                settingsVersion: '1.3.0',
+                downloadFolder: prev.downloadFolder,
+                pipelineInstanceProps: {
+                    pipelineType: 'embedded',
+                    pipelineHome: localPipelineHome,
+                    ...prevPipelinePros,
+                },
+                onClosingMainWindow:
+                    appStateOnClosingMainWindow == undefined
+                        ? undefined
+                        : appStateOnClosingMainWindow == 'ask'
+                        ? 'ask'
+                        : appStateOnClosingMainWindow == 'close'
+                        ? 'close'
+                        : jobsStateOnClosingMainWindow == 'close'
+                        ? 'keepengine'
+                        : 'keepall',
+                ...toKeep,
+            } as ApplicationSettings
+        },
+    ],
+])
+
+/////// Keeping previous applications settings here for history and for migrators
+/**
+ * Initial version of settings
+ */
+type _ApplicationSettings_v0 = {
     // Default folder to download the results on the user disk
     downloadFolder?: string
     // Local pipeline server
     // - Run or not a local pipeline server
     runLocalPipeline?: boolean
     // - Local pipeline settings
-    localPipelineProps?: PipelineInstanceProperties
+    localPipelineProps?: {
+        /**
+         * optional path of the local installation of the pipeline,
+         *
+         * defaults to the application resources/daisy-pipeline
+         */
+        localPipelineHome?: string
+        appDataFolder?: string
+        logsFolder?: string
+        /**
+         * optional path to the java runtime
+         *
+         * defaults to the application resource/jre folder
+         */
+        jrePath?: string
+        /**
+         * Webservice configuration to use for embedded pipeline,
+         *
+         * defaults to a localhost managed configuration :
+         * ```js
+         * {
+         *      host: "localhost"
+         *      port: 0, // will search for an available port on the current host when calling launch() the first time
+         *      path: "/ws"
+         * }
+         * ```
+         *
+         */
+        webservice?: Webservice
+        /**
+         *
+         */
+        onError?: (error: string) => void
+        onMessage?: (message: string) => void
+    }
     // Remote pipeline settings
     // - Use a remote pipeline instead of the local one
     useRemotePipeline?: boolean
@@ -34,8 +174,8 @@ export type ApplicationSettings = {
     // Dark mode selector
     colorScheme: keyof typeof ColorScheme
     // Actions to perform when closing the main window
-    appStateOnClosingMainWindow?: keyof typeof ClosingMainWindowActionForApp
-    jobsStateOnClosingMainWindow?: keyof typeof ClosingMainWindowActionForJobs
+    appStateOnClosingMainWindow?: 'keep' | 'close' | 'ask'
+    jobsStateOnClosingMainWindow?: 'keep' | 'close'
     // tts preferred voices
     ttsConfig?: TtsConfig
     autoCheckUpdate?: boolean


### PR DESCRIPTION
Introducing a setting migrator to allow safer changes of settings across versions when changes are required
(like merging or splitting settings)

A first migrator is provided to migrate current settings to a new version, including :
- merging the action setting for jobs and app on closing the main window (see #129)
- Adding a new setting to control if a job edition should be done in place or in a new job page (to prepare #130)
- cleaning up pipeline instance properties stored in settings
