### PR TITLE
feat(#139): retrieve job log in result folder and delete remote job

### DIFF
--- a/src/main/data/middlewares/pipeline.ts
+++ b/src/main/data/middlewares/pipeline.ts
@@ -149,6 +149,7 @@ async function downloadJobLog(j: Job, targetFolder: string) {
                     log: jobTargetUrl,
                     results: {
                         ...j.jobData.results,
+                        namedResults: [...j.jobData.results.namedResults],
                     },
                 },
             } as Job
@@ -185,7 +186,7 @@ async function downloadJobResults(j: Job, targetFolder: string) {
                 },
             } as Job
         })
-        .then((j: Job) => downloadJobLog(j, targetFolder))
+        .then(async (j: Job) => await downloadJobLog(j, targetFolder))
 }
 
 /**

--- a/src/shared/data/apis/pipeline.ts
+++ b/src/shared/data/apis/pipeline.ts
@@ -129,6 +129,12 @@ export class PipelineAPI {
             }
         )
     }
+    fetchJobLog(j: Job) {
+        return this.createPipelineFetchFunction(
+            () => j.jobData.log,
+            (text) => text
+        )
+    }
     launchJob(j: Job) {
         return this.createPipelineFetchFunction(
             (ws) => `${baseurl(ws)}/jobs`,
@@ -143,6 +149,13 @@ export class PipelineAPI {
             }
         )
     }
+    /**
+     * Delete a job in the pipeline
+     * @param j the job to delete
+     * @returns the http response of the webserver. Expected codes are <br/>
+     * - 204 on job removal
+     * - 404 if the job does not exists (i.e. if it has already been removed)
+     */
     deleteJob(j: Job) {
         return this.createPipelineRequestFunction(() => j.jobData.href, {
             method: 'DELETE',


### PR DESCRIPTION
Proposal PR to also fetch and save job logs in the result folder and delete the job data in the engine afterward.