### PR TITLE
feat: embedding command line in the qpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ engine/target/assembly-$(ENGINE_VERSION)-$(zip_classifier).zip : \
 		$(shell Files.walk(Paths.get("engine/src")).filter(Files::isRegularFile).forEach(System.out::println);)
 	exec("$(MAKE)", "-C", "engine", "zip-$(zip_classifier)",         \
 	                                "--", "--without-osgi",          \
-			                        "--without-cli",                 \
 			                        "--without-updater",             \
 			                        "--without-persistence");
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,5 +1,13 @@
-#### DAISY Pipeline 2 uninstall script ####
+!ifndef BUILD_UNINSTALLER
+  !include "StrFunc.nsh"  
+  ${StrStr}
+!else
+  !include "StrFunc.nsh"  
+  ${UnStrStr}
+!endif
 
+
+#### DAISY Pipeline 2 uninstall script ####
 !macro RemovePreviousDP2
   !define DP2_KEY "SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\UninstallDAISY Pipeline 2DAISY Consortium DAISY Pipeline 2"
     ; Uninstall key of a previous DP2 installation (tested with installer of DP2 version 1.14.11)
@@ -22,4 +30,75 @@
 
 !macro customInit
   !insertmacro RemovePreviousDP2
+!macroend
+
+;Install app and cli utility in path
+!macro customInstall
+    ; Get the user PATH value (in $0)
+    ReadRegStr $0 HKCU "Environment" "Path"
+    IntOp $6 0 + 0;
+
+    ; Check if $0 ends with a ';'
+    StrLen $2 $0
+    IntOp $2 $2 - 1
+    StrCpy $3 $0 1 $2
+    StrCmp $3 ";" pathEndsWithSemicolon 0 ; If not ending with a ';', append it
+      StrCpy $0 "$0;"
+    pathEndsWithSemicolon:
+
+    ${StrStr} $1 $0 "$INSTDIR;"
+    StrCmp $1 "" 0  AppIsInPath
+      StrCpy $0 "$0$INSTDIR;"
+      IntOp $6 0 + 1;
+    AppIsInPath:
+    
+    ${StrStr} $1 $0 "$INSTDIR\resources\app.asar.unpacked\resources\daisy-pipeline\cli;"
+    StrCmp $1 "" 0  CliInPath
+      StrCpy $0 "$0$INSTDIR\resources\app.asar.unpacked\resources\daisy-pipeline\cli;"
+      IntOp $6 0 + 1;
+    CliInPath:
+
+    IntCmp $6 0 EndCustomInstall
+      WriteRegExpandStr HKCU "Environment" "Path" "$0"
+    EndCustomInstall:
+!macroend
+
+; TODO I'd like to remove the path from the user PATH
+; but i can't find a way to make electron-builder to accept
+; any script in the uninstaller.nsh file
+; in the following, despite being documented in NSIS
+; the command  UnStrStr is refused
+!macro customUnInstall
+  ; Get the user PATH value (in $0)
+  ReadRegStr $0 HKCU "Environment" "Path"
+  IntOp $6 0 + 0;
+
+  StrLen $3 "$INSTDIR\resources\app.asar.unpacked\resources\daisy-pipeline\cli;" ; size of instdir
+  StrLen $4 $0 ; size of the path value
+  ${UnStrStr} $1 $0 "$INSTDIR\resources\app.asar.unpacked\resources\daisy-pipeline\cli;" ; substring position of instdir in path
+  StrCmp $1 "" CliIsNotInPath 0 ; if substring is empty, no modification, else continue
+    StrLen $5 $1 ; size of the substring
+    IntOp $5 $4 - $5 ; pathSize - substringSize
+    StrCpy $0 $0 $5 ; $0 = substring(str=$0, start=0, len=$5)
+    StrCpy $1 $1 "" $3 ; $1 = substring(str=$1, start=$3)
+    StrCpy $0 "$0$1"
+    IntOp $6 0 + 1;
+  CliIsNotInPath:
+  
+  StrLen $3 "$INSTDIR;" ; size of instdir
+  StrLen $4 $0 ; size of the path value
+  ${UnStrStr} $1 $0 "$INSTDIR;" ; substring position of instdir in path
+  StrCmp $1 "" AppIsNotInPath 0 ; if substring is empty, no modification, else continue
+    StrLen $5 $1 ; size of the substring
+    IntOp $5 $4 - $5 ; pathSize - substringSize
+    StrCpy $0 $0 $5 ; $0 = substring(str=$0, start=0, len=$5)
+    StrCpy $1 $1 "" $3 ; $1 = substring(str=$1, start=$3)
+    StrCpy $0 "$0$1"
+    IntOp $6 0 + 1;
+  AppIsNotInPath:
+
+  IntCmp $6 0 EndCustomUnInstall
+    WriteRegExpandStr HKCU "Environment" "Path" "$0"
+  EndCustomUnInstall:
+  
 !macroend

--- a/buildmac/pkg-scripts/postinstall
+++ b/buildmac/pkg-scripts/postinstall
@@ -3,6 +3,11 @@
 #   this file is automatically detected by electron-builder as a postinstall script
 #   due to its folder location and filename
 
+# Create simlinks to the app in usr local bon to allow its use as cli
+ln -sfn $2/DAISY\ Pipeline.app/Contents/MacOS/DAISY\ Pipeline /usr/local/bin/DAISY\ Pipeline
+ln -sfn $2/DAISY\ Pipeline.app/Contents/Resources/app.asar.unpacked/resources/daisy-pipeline/cli/dp2 /usr/local/bin/dp2
+
+
 remove_app () {
     APP=$1
     # Get a list of all installed app's, filter to only have /Applications and /User/<username>/Applications, filter the requested app, select the first found app

--- a/src/main/data/middlewares/pipeline.ts
+++ b/src/main/data/middlewares/pipeline.ts
@@ -53,10 +53,13 @@ import { pipelineAPI } from '../apis/pipeline'
 import { PayloadAction } from '@reduxjs/toolkit'
 import { saveFile, unzipFile } from 'main/factories/ipcs/file'
 import {
+    save,
     selectDownloadPath,
     selectPipelineProperties,
     selectSettings,
     selectTtsConfig,
+    setPipelineProperties,
+    setSettings,
 } from 'shared/data/slices/settings'
 import { ParserException } from 'shared/parser/pipelineXmlConverter/parser'
 import { PipelineInstance } from 'main/factories'
@@ -409,6 +412,20 @@ export function pipelineMiddleware({ getState, dispatch }) {
                                     'useWebservice',
                                     'Pipeline is ready to be used'
                                 )
+                                // Save the pipeline properties in settings
+                                // and save settings
+                                const { onError, onMessage, ...serializable } =
+                                    getPipelineInstance(state).props
+                                dispatch(
+                                    setPipelineProperties({
+                                        ...serializable,
+                                        webservice: {
+                                            ...newWebservice,
+                                            lastStart: Date.now(),
+                                        },
+                                    })
+                                )
+                                dispatch(save())
                                 dispatch(setAlive(alive))
                             })
                             .then(() => fetchScripts(newWebservice))

--- a/src/main/data/middlewares/settings.ts
+++ b/src/main/data/middlewares/settings.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 import { app, nativeTheme } from 'electron'
-import { info, error } from 'electron-log'
+import { info, error, debug } from 'electron-log'
 import { existsSync, readFileSync, writeFile } from 'fs'
 import { resolve } from 'path'
 import { ENVIRONMENT } from 'shared/constants'
@@ -96,8 +96,10 @@ export function readSettings() {
                         : settings.ttsConfig.xmlFilepath,
                 },
             }
-            info(`Settings loaded from ${settingsFile}`)
-            info(JSON.stringify(settings))
+            if (ENVIRONMENT.IS_DEV) {
+                debug(`Settings loaded from ${settingsFile}`)
+                debug(JSON.stringify(settings))
+            }
         } else {
             error(`${settingsFile} not found`)
             throw new Error(`${settingsFile} not found`)

--- a/src/main/data/middlewares/settings.ts
+++ b/src/main/data/middlewares/settings.ts
@@ -41,6 +41,7 @@ export function readSettings() {
                 host: '127.0.0.1',
                 port: 0,
                 path: '/ws',
+                lastStart: 0,
             },
             pipelineHome: resolveUnpacked('resources', 'daisy-pipeline'),
             jrePath: resolveUnpacked('resources', 'daisy-pipeline', 'jre'),
@@ -121,7 +122,7 @@ export function readSettings() {
     }
 
     // Remove pipeline props loading for dev
-    if (ENVIRONMENT.IS_DEV) settings.pipelineInstanceProps = undefined
+    //if (ENVIRONMENT.IS_DEV) settings.pipelineInstanceProps = undefined
 
     return settings
 }
@@ -172,7 +173,7 @@ export function settingsMiddleware({ getState, dispatch }) {
                         new URL(settings.ttsConfig.xmlFilepath),
                         ttsConfigToXml(settings.ttsConfig),
                         () => {
-                            console.log("wrote file, setting engine property")
+                            //console.log("wrote file, setting engine property")
                             const webservice = selectWebservice(getState())
                             let ttsConfig = selectTtsConfig(getState())
                             console.log(ttsConfig)

--- a/src/main/factories/app/cli.ts
+++ b/src/main/factories/app/cli.ts
@@ -6,8 +6,7 @@
 import { store } from 'main/data/store'
 import { getPipelineInstance } from 'main/data/middlewares/pipeline'
 import path from 'path'
-import { cwd } from 'process'
-import { spawnSync, spawn, execSync } from 'child_process'
+import { spawnSync } from 'child_process'
 import { existsSync } from 'fs'
 import { Webservice } from 'shared/types'
 

--- a/src/main/factories/app/cli.ts
+++ b/src/main/factories/app/cli.ts
@@ -1,0 +1,48 @@
+/**
+ * Parsing command line to create jobs
+ * @param {Array<string>} commandLineArgs command line arguments
+ */
+
+import { store } from 'main/data/store'
+import { getPipelineInstance } from 'main/data/middlewares/pipeline'
+import path from 'path'
+import { cwd } from 'process'
+import { spawnSync, spawn, execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { Webservice } from 'shared/types'
+
+/**
+ * Run the cli utility from within the app
+ * @param args cli arguments
+ */
+export function runCliTool(ws: Webservice, args: string[]) {
+    const cliTool = path.resolve(
+        getPipelineInstance(store.getState()).props.pipelineHome,
+        'cli',
+        'dp2' + (process.platform === 'win32' ? '.exe' : '')
+    )
+    if (!existsSync(cliTool)) {
+        console.error(
+            'Pipeline app embedded pipeline is not distributed with the cli tools, aborting launch, please update your pipeline app'
+        )
+        return
+    }
+    var childProcess = spawnSync(
+        cliTool,
+        [
+            '--port',
+            ws.port.toString(),
+            '--host',
+            `${ws.ssl ? 'https://' : 'http://'}${ws.host}`,
+            '--ws_path',
+            `${ws.path.startsWith('/') ? ws.path.slice(1) : ws.path}`,
+            ...args,
+        ],
+        {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: [null, process.stdout, process.stderr],
+            encoding: 'utf-8',
+        }
+    )
+}

--- a/src/main/factories/app/instance.ts
+++ b/src/main/factories/app/instance.ts
@@ -1,34 +1,84 @@
 import { app } from 'electron'
 
 import { spawn } from 'child_process'
+import { readSettings } from 'main/data/middlewares'
+import { runCliTool } from './cli'
+
+async function getWebserviceFromSettings(remain: number, startingTime: number) {
+    if (remain == 0) {
+        throw new Error('Max attempts reached')
+    } else {
+        try {
+            const settings = readSettings()
+            if (
+                settings?.pipelineInstanceProps?.webservice?.lastStart >
+                startingTime
+            ) {
+                return settings?.pipelineInstanceProps?.webservice
+            }
+        } catch (error) {}
+        const test = Date.now()
+        // Does not work but i don't know why ... possibly an issue
+        // with my nodejs version
+        //await setTimeout(1000)
+        // ugly but it works
+        do {} while (Date.now() - test < 3000)
+        return await getWebserviceFromSettings(remain - 1, startingTime)
+    }
+}
+
+const reservedFlag = ['--bg', '--hidden']
 
 export function makeAppWithSingleInstanceLock(fn: () => void) {
     const isPrimaryInstance = app.requestSingleInstanceLock()
-    if (
-        (process.argv.includes('--bg') || process.argv.includes('cli')) &&
-        isPrimaryInstance
-    ) {
-        // launch a separate instance
-        app.quit()
-        const isElectron = process.argv[0]
-            .replaceAll('.exe', '')
-            .endsWith('electron')
-        console.log('launching the pipeline app in the background')
-        const appLaunchArgs = isElectron
-            ? [...process.argv.slice(0, 2)]
-            : process.argv.slice(0, 1)
-        spawn(
-            appLaunchArgs[0],
-            [...(isElectron ? appLaunchArgs.slice(1) : []), '--hidden'],
-            {
+    const isElectron = process.argv[0]
+        .replaceAll('.exe', '')
+        .endsWith('electron')
+    const appLaunchArgs = process.argv.slice(0, isElectron ? 2 : 1)
+    const commandLineArgs = process.argv
+        .slice(isElectron ? 2 : 1)
+        .filter((arg) => !reservedFlag.includes(arg))
+    const startingTime = isPrimaryInstance ? Date.now() : 0
+    if (isPrimaryInstance) {
+        // basic initialisation of the app if
+        // it does not have cli args or background launch is not requested
+        if (commandLineArgs.length == 0 && !process.argv.includes('--bg')) {
+            fn()
+        } else {
+            // Command line args are reported or the background launch is requested
+            // Quit the app so that it can be launched in the background
+            // in a separate process
+            app.quit()
+            // launch the app in the background
+            const bgInstanceArgs = [
+                // Launch commands for electron
+                ...(isElectron ? [appLaunchArgs[1]] : []),
+                // If command line arguments are provided (for cli usage),
+                // launch the app in hidden mode
+                ...(commandLineArgs.length > 0 ? ['--hidden'] : []),
+            ]
+
+            // launch the app in detached mode in a separate process
+            const child = spawn(appLaunchArgs[0], bgInstanceArgs, {
                 cwd: process.cwd(),
-                detached: true,
+                env: process.env,
+                detached: !isElectron,
                 shell: isElectron,
                 stdio: 'ignore',
-            }
-        )
-        // wait 5 seconds to ensure the app is launched
+            })
+        }
     } else {
-        !isPrimaryInstance ? app.quit() : fn()
+        // We are launching a secondary instance
+        // Do not continue the original app launch
+        app.quit()
+    }
+    if (commandLineArgs.length > 0) {
+        getWebserviceFromSettings(5, startingTime)
+            .then((webservice) => {
+                runCliTool(webservice, commandLineArgs)
+            })
+            .catch((error) => {
+                console.error('Error:', error)
+            })
     }
 }

--- a/src/main/factories/app/instance.ts
+++ b/src/main/factories/app/instance.ts
@@ -33,7 +33,7 @@ export function makeAppWithSingleInstanceLock(fn: () => void) {
     let commandLineArgs = []
     let appLaunchArgs = []
     if (process.argv) {
-        isElectron = process.argv[0].replaceAll('.exe', '').endsWith('electron')
+        isElectron = process.argv[0].replaceAll('.exe', '').toLowerCase().endsWith('electron')
         appLaunchArgs = process.argv.slice(0, isElectron ? 2 : 1)
         commandLineArgs = process.argv
             .slice(isElectron ? 2 : 1)

--- a/src/main/factories/app/instance.ts
+++ b/src/main/factories/app/instance.ts
@@ -20,8 +20,7 @@ async function getWebserviceFromSettings(remain: number, startingTime: number) {
         const test = Date.now()
         // Does not work but i don't know why ... possibly an issue
         // with my nodejs version
-        //await setTimeout(1000)
-        // ugly but it works
+        // ugly but it works to check every 3 seconds
         do {} while (Date.now() - test < 3000)
         return await getWebserviceFromSettings(remain - 1, startingTime)
     }
@@ -62,7 +61,9 @@ export function makeAppWithSingleInstanceLock(fn: () => void) {
                 // launch the app in hidden mode
                 ...(commandLineArgs.length > 0 ? ['--hidden'] : []),
             ]
-
+            console.log(
+                'Launching the app in the background and wait for the webservice ...'
+            )
             // launch the app in detached mode in a separate process
             const child = spawn(appLaunchArgs[0], bgInstanceArgs, {
                 cwd: process.cwd(),
@@ -78,7 +79,7 @@ export function makeAppWithSingleInstanceLock(fn: () => void) {
         app.quit()
     }
     if (commandLineArgs.length > 0) {
-        getWebserviceFromSettings(5, startingTime)
+        getWebserviceFromSettings(10, startingTime)
             .then((webservice) => {
                 runCliTool(webservice, commandLineArgs)
             })

--- a/src/main/factories/app/instance.ts
+++ b/src/main/factories/app/instance.ts
@@ -30,14 +30,19 @@ async function getWebserviceFromSettings(remain: number, startingTime: number) {
 const reservedFlag = ['--bg', '--hidden']
 
 export function makeAppWithSingleInstanceLock(fn: () => void) {
-    const isPrimaryInstance = app.requestSingleInstanceLock()
-    const isElectron = process.argv[0]
-        .replaceAll('.exe', '')
-        .endsWith('electron')
-    const appLaunchArgs = process.argv.slice(0, isElectron ? 2 : 1)
-    const commandLineArgs = process.argv
-        .slice(isElectron ? 2 : 1)
-        .filter((arg) => !reservedFlag.includes(arg))
+    let isElectron = false
+    let commandLineArgs = []
+    let appLaunchArgs = []
+    if (process.argv) {
+        isElectron = process.argv[0].replaceAll('.exe', '').endsWith('electron')
+        appLaunchArgs = process.argv.slice(0, isElectron ? 2 : 1)
+        commandLineArgs = process.argv
+            .slice(isElectron ? 2 : 1)
+            .filter((arg) => !reservedFlag.includes(arg))
+    }
+    const isPrimaryInstance = app.requestSingleInstanceLock({
+        argv: commandLineArgs,
+    })
     const startingTime = isPrimaryInstance ? Date.now() : 0
     if (isPrimaryInstance) {
         // basic initialisation of the app if

--- a/src/main/factories/app/instance.ts
+++ b/src/main/factories/app/instance.ts
@@ -1,7 +1,34 @@
 import { app } from 'electron'
 
+import { spawn } from 'child_process'
+
 export function makeAppWithSingleInstanceLock(fn: () => void) {
     const isPrimaryInstance = app.requestSingleInstanceLock()
-
-    !isPrimaryInstance ? app.quit() : fn()
+    if (
+        (process.argv.includes('--bg') || process.argv.includes('cli')) &&
+        isPrimaryInstance
+    ) {
+        // launch a separate instance
+        app.quit()
+        const isElectron = process.argv[0]
+            .replaceAll('.exe', '')
+            .endsWith('electron')
+        console.log('launching the pipeline app in the background')
+        const appLaunchArgs = isElectron
+            ? [...process.argv.slice(0, 2)]
+            : process.argv.slice(0, 1)
+        spawn(
+            appLaunchArgs[0],
+            [...(isElectron ? appLaunchArgs.slice(1) : []), '--hidden'],
+            {
+                cwd: process.cwd(),
+                detached: true,
+                shell: isElectron,
+                stdio: 'ignore',
+            }
+        )
+        // wait 5 seconds to ensure the app is launched
+    } else {
+        !isPrimaryInstance ? app.quit() : fn()
+    }
 }

--- a/src/main/factories/ipcs/pipeline.ts
+++ b/src/main/factories/ipcs/pipeline.ts
@@ -248,6 +248,37 @@ Then close the program using the port and restart this application.`,
             info(
                 `Launching pipeline on ${this.props.webservice.host}:${this.props.webservice.port}`
             )
+            // Update the cli config file with the new werbservice informations
+            const cliConfigFile = resolve(
+                this.props.pipelineHome,
+                'cli',
+                'config.yml'
+            )
+            if (existsSync(cliConfigFile)) {
+                let cliConfig = readFileSync(cliConfigFile, 'utf8')
+                cliConfig = cliConfig
+                    .replace(
+                        /host:.*\n/,
+                        `host: ${
+                            (this.props.webservice.ssl
+                                ? 'https://'
+                                : 'http://') + this.props.webservice.host
+                        }\n`
+                    )
+                    .replace(
+                        /port:.*\n/,
+                        `port: ${this.props.webservice.port}\n`
+                    )
+                    .replace(
+                        /ws_path:.*\n/,
+                        `ws_path: ${
+                            this.props.webservice.path.startsWith('/')
+                                ? this.props.webservice.path.slice(1)
+                                : this.props.webservice.path
+                        }\n`
+                    )
+                fs.writeFileSync(cliConfigFile, cliConfig)
+            }
             let ClassFolders = [
                 resolve(this.props.pipelineHome, 'system'),
                 resolve(this.props.pipelineHome, 'modules'),

--- a/src/main/factories/ipcs/pipeline.ts
+++ b/src/main/factories/ipcs/pipeline.ts
@@ -254,31 +254,40 @@ Then close the program using the port and restart this application.`,
                 'cli',
                 'config.yml'
             )
-            if (existsSync(cliConfigFile)) {
-                let cliConfig = readFileSync(cliConfigFile, 'utf8')
-                cliConfig = cliConfig
-                    .replace(
-                        /host:.*\n/,
-                        `host: ${
-                            (this.props.webservice.ssl
-                                ? 'https://'
-                                : 'http://') + this.props.webservice.host
-                        }\n`
-                    )
-                    .replace(
-                        /port:.*\n/,
-                        `port: ${this.props.webservice.port}\n`
-                    )
-                    .replace(
-                        /ws_path:.*\n/,
-                        `ws_path: ${
-                            this.props.webservice.path.startsWith('/')
-                                ? this.props.webservice.path.slice(1)
-                                : this.props.webservice.path
-                        }\n`
-                    )
-                fs.writeFileSync(cliConfigFile, cliConfig)
+            try{
+                if (existsSync(cliConfigFile)) {
+                    let cliConfig = readFileSync(cliConfigFile, 'utf8')
+                    cliConfig = cliConfig
+                        .replace(
+                            /host:.*\n/,
+                            `host: ${
+                                (this.props.webservice.ssl
+                                    ? 'https://'
+                                    : 'http://') + this.props.webservice.host
+                            }\n`
+                        )
+                        .replace(
+                            /port:.*\n/,
+                            `port: ${this.props.webservice.port}\n`
+                        )
+                        .replace(
+                            /ws_path:.*\n/,
+                            `ws_path: ${
+                                this.props.webservice.path.startsWith('/')
+                                    ? this.props.webservice.path.slice(1)
+                                    : this.props.webservice.path
+                            }\n`
+                        )
+                    fs.writeFileSync(cliConfigFile, cliConfig)
+                }
+            } catch (error){
+                // Note : on macos, with the dp2 tool included in the app, the configuration cannot be updated
+                // it raises a permission denied
+                // for now i think i'll just keep it in its current state
+                // as the next dp2 tool should check for the presence of the DAISY Pipeline application
+                //console.log("Warning : could not update the embedded dp2 configuration for reuse", error)
             }
+            
             let ClassFolders = [
                 resolve(this.props.pipelineHome, 'system'),
                 resolve(this.props.pipelineHome, 'modules'),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,24 +106,21 @@ makeAppWithSingleInstanceLock(async () => {
     //  and the existing one receive this event along the passed command line arguments of the killed on)
     app.on(
         'second-instance',
-        (event, commandLine, workingDirectory, additionalData) => {
-            MainWindow().then((window) => {
-                // Parse command line to create a new job from command line
-                // possibly following pipeline 2 original command line tool
-                //parsePipelineCommands(commandLine)
-                if (
-                    !(
-                        commandLine.includes('--bg') ||
-                        commandLine.includes('--hidden') ||
-                        commandLine.includes('cli')
-                    )
-                ) {
+        (
+            event,
+            commandLine,
+            workingDirectory,
+            additionalData: { argv: string[] }
+        ) => {
+            const cliArgs = additionalData?.argv || []
+            if (!commandLine.includes('--hidden') && cliArgs.length == 0) {
+                MainWindow().then((window) => {
                     if (window.isMinimized()) {
                         window.restore()
                     }
                     window.focus()
-                }
-            })
+                })
+            }
         }
     )
     if (store.getState().settings.autoCheckUpdate) {

--- a/src/shared/data/slices/settings.ts
+++ b/src/shared/data/slices/settings.ts
@@ -23,6 +23,7 @@ export const settings = createSlice({
                 host: '127.0.0.1',
                 port: 0,
                 path: '/ws',
+                lastStart: 0,
             },
         } as PipelineInstanceProperties,
         colorScheme: 'system',

--- a/src/shared/types/pipeline.ts
+++ b/src/shared/types/pipeline.ts
@@ -14,6 +14,7 @@ export type Webservice = {
     port?: number
     path?: string
     ssl?: boolean
+    lastStart?: number
 }
 /**
  * Utility function to get base url string from webservice


### PR DESCRIPTION
The following PR includes:
- Embeding the pipeline-cli (dp2) utility in the app package
- Register the app and the embedded dp2 in the user path : 
  - For Windows : the install script add the pathes of the app and dp2 folders in the user PATH variable
  - For MacOS : the post-install script adds symlinks to app and dp2 in the `/usr/local/bin` folder
 
The expected behavior when launching the app from the command line 
- If no arguments are provided, the app launch as usual
- When passing arguments to the app executable or if the `--bg` flag is given, 
  - the app launches itself in the background in a separate process
  - If there are command line arguments, the app then launches the embedded dp2 utility with host, port and path of the embedded engine and forward the arguments to it.

2 command line flags are checked in the app :
- `--bg`  (as 'background') tries to launch the app in the background (i.e. in a separate process) if it is not already launched
- `--hidden` keep the app minimized (like launched in the system tray) 

